### PR TITLE
Use logging level DEBUG instead of INFO when inspecting the files

### DIFF
--- a/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/ParsingUtils.java
+++ b/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/ParsingUtils.java
@@ -54,7 +54,7 @@ public class ParsingUtils {
         if (!myEnum.getInterfaces().contains(requiredClass.getCanonicalName())) {
             return;
         }
-        logger.info("Checking [" + parentEnum.getName() + "." + myEnum.getName() + "]");
+        logger.debug("Checking [" + parentEnum.getName() + "." + myEnum.getName() + "]");
         if (myEnum.getEnumConstants().size() == 0) {
             return;
         }

--- a/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/DocsFromSources.java
+++ b/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/DocsFromSources.java
@@ -55,7 +55,7 @@ public class DocsFromSources {
 
     public void generate() {
         Path path = this.projectRoot.toPath();
-        logger.info("Path is [" + this.projectRoot.getAbsolutePath() + "]. Inclusion pattern is [" + this.inclusionPattern + "]");
+        logger.debug("Path is [" + this.projectRoot.getAbsolutePath() + "]. Inclusion pattern is [" + this.inclusionPattern + "]");
         Collection<MetricEntry> entries = new TreeSet<>();
         FileVisitor<Path> fv = new MetricSearchingFileVisitor(this.inclusionPattern, entries);
         try {
@@ -66,15 +66,15 @@ public class DocsFromSources {
                 file.getParentFile().mkdirs();
                 file.createNewFile();
             }
-            logger.info("Will create files under [" + file + "]");
+            logger.debug("Will create files under [" + file + "]");
             StringBuilder stringBuilder = new StringBuilder();
             Path output = file.toPath();
-            logger.info("======================================");
-            logger.info("Summary of sources analysis");
-            logger.info("Found [" + entries.size() + "] samples");
-            logger.info(
+            logger.debug("======================================");
+            logger.debug("Summary of sources analysis");
+            logger.debug("Found [" + entries.size() + "] samples");
+            logger.debug(
                     "Found [" + entries.stream().flatMap(e -> e.lowCardinalityKeyNames.stream()).distinct().count() + "] low cardinality tags");
-            logger.info(
+            logger.debug(
                     "Found [" + entries.stream().flatMap(e -> e.highCardinalityKeyNames.stream()).distinct().count() + "] high cardinality tags");
             stringBuilder.append("[[observability-metrics]]\n=== Observability - Metrics\n\nBelow you can find a list of all samples declared by this project.\n\n");
             entries.forEach(metricEntry -> stringBuilder.append(metricEntry.toString()).append("\n\n"));

--- a/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricSearchingFileVisitor.java
+++ b/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricSearchingFileVisitor.java
@@ -78,7 +78,7 @@ class MetricSearchingFileVisitor extends SimpleFileVisitor<Path> {
             if (Stream.of(DocumentedMeter.class.getCanonicalName(), DocumentedObservation.class.getCanonicalName()).noneMatch(ds -> myEnum.getInterfaces().contains(ds))) {
                 return FileVisitResult.CONTINUE;
             }
-            logger.info("Checking [" + myEnum.getName() + "]");
+            logger.debug("Checking [" + myEnum.getName() + "]");
             if (myEnum.getEnumConstants().size() == 0) {
                 return FileVisitResult.CONTINUE;
             }
@@ -86,7 +86,7 @@ class MetricSearchingFileVisitor extends SimpleFileVisitor<Path> {
                 MetricEntry entry = parseMetric(enumConstant, myEnum);
                 if (entry != null) {
                     sampleEntries.add(entry);
-                    logger.info(
+                    logger.debug(
                             "Found [" + entry.lowCardinalityKeyNames.size() + "] low cardinality tags and [" + entry.highCardinalityKeyNames.size() + "] high cardinality tags");
                 }
                 if (entry != null) {
@@ -94,7 +94,7 @@ class MetricSearchingFileVisitor extends SimpleFileVisitor<Path> {
                         addTagsFromOverride(file, entry);
                     }
                     sampleEntries.add(entry);
-                    logger.info(
+                    logger.debug(
                             "Found [" + entry.lowCardinalityKeyNames.size() + "]");
                 }
             }
@@ -110,7 +110,7 @@ class MetricSearchingFileVisitor extends SimpleFileVisitor<Path> {
     // if entry has overridesDefaultSpanFrom AND getAdditionalKeyNames() - we pick both
     private void addTagsFromOverride(Path file, MetricEntry entry) throws IOException {
         Map.Entry<String, String> overrideDefaults = entry.overridesDefaultMetricFrom;
-        logger.info("Reading additional meta data from [" + overrideDefaults + "]");
+        logger.debug("Reading additional meta data from [" + overrideDefaults + "]");
         String className = overrideDefaults.getKey();
         File parent = file.getParent().toFile();
         while (!parent.getAbsolutePath().endsWith(File.separator + "java")) {
@@ -127,7 +127,7 @@ class MetricSearchingFileVisitor extends SimpleFileVisitor<Path> {
             if (!myEnum.getInterfaces().contains(DocumentedObservation.class.getCanonicalName())) {
                 return;
             }
-            logger.info("Checking [" + myEnum.getName() + "]");
+            logger.debug("Checking [" + myEnum.getName() + "]");
             if (myEnum.getEnumConstants().size() == 0) {
                 return;
             }

--- a/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/DocsFromSources.java
+++ b/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/DocsFromSources.java
@@ -54,7 +54,7 @@ public class DocsFromSources {
 
     public void generate() {
         Path path = this.projectRoot.toPath();
-        logger.info("Path is [" + this.projectRoot.getAbsolutePath() + "]. Inclusion pattern is [" + this.inclusionPattern + "]");
+        logger.debug("Path is [" + this.projectRoot.getAbsolutePath() + "]. Inclusion pattern is [" + this.inclusionPattern + "]");
         Collection<SpanEntry> spanEntries = new TreeSet<>();
         FileVisitor<Path> fv = new SpanSearchingFileVisitor(this.inclusionPattern, spanEntries);
         try {
@@ -62,12 +62,12 @@ public class DocsFromSources {
             SpanEntry.assertThatProperlyPrefixed(spanEntries);
             Path output = new File(this.outputDir, "_spans.adoc").toPath();
             StringBuilder stringBuilder = new StringBuilder();
-            logger.info("======================================");
-            logger.info("Summary of sources analysis");
-            logger.info("Found [" + spanEntries.size() + "] spans");
-            logger.info(
+            logger.debug("======================================");
+            logger.debug("Summary of sources analysis");
+            logger.debug("Found [" + spanEntries.size() + "] spans");
+            logger.debug(
                     "Found [" + spanEntries.stream().flatMap(e -> e.tagKeys.stream()).distinct().count() + "] tags");
-            logger.info(
+            logger.debug(
                     "Found [" + spanEntries.stream().flatMap(e -> e.events.stream()).distinct().count() + "] events");
             stringBuilder.append("[[observability-spans]]\n=== Observability - Spans\n\nBelow you can find a list of all spans declared by this project.\n\n");
             spanEntries.forEach(spanEntry -> stringBuilder.append(spanEntry.toString()).append("\n\n"));

--- a/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/SpanSearchingFileVisitor.java
+++ b/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/SpanSearchingFileVisitor.java
@@ -80,7 +80,7 @@ class SpanSearchingFileVisitor extends SimpleFileVisitor<Path> {
             if (Stream.of(DocumentedSpan.class.getCanonicalName(), DocumentedObservation.class.getCanonicalName()).noneMatch(ds -> myEnum.getInterfaces().contains(ds))) {
                 return FileVisitResult.CONTINUE;
             }
-            logger.info("Checking [" + myEnum.getName() + "]");
+            logger.debug("Checking [" + myEnum.getName() + "]");
             if (myEnum.getEnumConstants().size() == 0) {
                 return FileVisitResult.CONTINUE;
             }
@@ -94,7 +94,7 @@ class SpanSearchingFileVisitor extends SimpleFileVisitor<Path> {
                         entry.tagKeys.addAll(entry.additionalKeyNames);
                     }
                     spanEntries.add(entry);
-                    logger.info(
+                    logger.debug(
                             "Found [" + entry.tagKeys.size() + "] tags and [" + entry.events.size() + "] events");
                 }
             }
@@ -114,7 +114,7 @@ class SpanSearchingFileVisitor extends SimpleFileVisitor<Path> {
                 .filter(spanEntry -> overridingNames.stream().anyMatch(name -> spanEntry.enclosingClass.toLowerCase(Locale.ROOT).contains(name.toLowerCase(Locale.ROOT))))
                 .collect(Collectors.toList());
         if (!spansToRemove.isEmpty()) {
-            logger.info("Will remove the span entries <" + spansToRemove.stream().map(s -> s.name).collect(Collectors.joining(",")) + "> because they are overridden");
+            logger.debug("Will remove the span entries <" + spansToRemove.stream().map(s -> s.name).collect(Collectors.joining(",")) + "> because they are overridden");
         }
         spanEntries.removeAll(spansToRemove);
         return FileVisitResult.CONTINUE;
@@ -125,7 +125,7 @@ class SpanSearchingFileVisitor extends SimpleFileVisitor<Path> {
     // if entry has overridesDefaultSpanFrom AND getAdditionalKeyNames() - we pick both
     private void addTagsFromOverride(Path file, SpanEntry entry) throws IOException {
         Map.Entry<String, String> overridesDefaultSpanFrom = entry.overridesDefaultSpanFrom;
-        logger.info("Reading additional meta data from [" + overridesDefaultSpanFrom + "]");
+        logger.debug("Reading additional meta data from [" + overridesDefaultSpanFrom + "]");
         String className = overridesDefaultSpanFrom.getKey();
         File parent = file.getParent().toFile();
         while (!parent.getAbsolutePath().endsWith(File.separator + "java")) {
@@ -142,7 +142,7 @@ class SpanSearchingFileVisitor extends SimpleFileVisitor<Path> {
             if (!myEnum.getInterfaces().contains(DocumentedObservation.class.getCanonicalName())) {
                 return;
             }
-            logger.info("Checking [" + myEnum.getName() + "]");
+            logger.debug("Checking [" + myEnum.getName() + "]");
             if (myEnum.getEnumConstants().size() == 0) {
                 return;
             }


### PR DESCRIPTION
With the current `INFO` logging level, when executing the task for
doc generation, the logs a flooded with information that typically
should be with `DEBUG` logging level

```
> Task :reactor-netty:generateObservabilityMetricsDocs
Jul 04, 2022 8:11:18 PM io.micrometer.docs.metrics.DocsFromSources generate
INFO: Path is [/.../reactor-netty]. Inclusion pattern is [.*]
Jul 04, 2022 8:11:19 PM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
INFO: Checking [HttpServerObservations]
Jul 04, 2022 8:11:19 PM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
INFO: Found [3] low cardinality tags and [3] high cardinality tags
Jul 04, 2022 8:11:19 PM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
INFO: Found [3]
Jul 04, 2022 8:11:19 PM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
INFO: Checking [HttpServerMeters]
Jul 04, 2022 8:11:19 PM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
INFO: Found [2] low cardinality tags and [0] high cardinality tags
Jul 04, 2022 8:11:19 PM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
INFO: Found [2]
Jul 04, 2022 8:11:19 PM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
INFO: Found [1] low cardinality tags and [0] high cardinality tags
Jul 04, 2022 8:11:19 PM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
INFO: Found [1]
Jul 04, 2022 8:11:19 PM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
INFO: Found [2] low cardinality tags and [0] high cardinality tags
Jul 04, 2022 8:11:19 PM io.micrometer.docs.metrics.MetricSearchingFileVisitor visitFile
INFO: Found [2]
...
```