### PR TITLE
Fail DocsFromSources on error while visiting files

### DIFF
--- a/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricEntry.java
+++ b/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricEntry.java
@@ -58,7 +58,7 @@ class MetricEntry implements Comparable<MetricEntry> {
     final Map.Entry<String, String> overridesDefaultMetricFrom;
 
     MetricEntry(String name, String conventionClass, String nameFromConventionClass, String enclosingClass, String enumName, String description, String prefix, String baseUnit, Meter.Type meterType, Collection<KeyValueEntry> lowCardinalityKeyNames, Collection<KeyValueEntry> highCardinalityKeyNames, Map.Entry<String, String> overridesDefaultMetricFrom) {
-        Assert.hasText(description, "Observation / Meter description must not be empty. Check <" + enclosingClass + "#" + enumName + ">");
+        Assert.hasText(description, "Observation / Meter javadoc description must not be empty. Check <" + enclosingClass + "#" + enumName + ">");
         this.name = name;
         this.conventionClass = conventionClass;
         this.nameFromConventionClass = nameFromConventionClass;

--- a/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricSearchingFileVisitor.java
+++ b/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricSearchingFileVisitor.java
@@ -120,9 +120,8 @@ class MetricSearchingFileVisitor extends SimpleFileVisitor<Path> {
             }
             return FileVisitResult.CONTINUE;
         } catch (Exception e) {
-            logger.error("Failed to parse file [" + file + "] due to an error", e);
+            throw new IOException("Failed to parse file [" + file + "] due to an error", e);
         }
-        return FileVisitResult.CONTINUE;
     }
 
     // TODO: Duplication

--- a/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/SpanEntry.java
+++ b/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/SpanEntry.java
@@ -56,7 +56,7 @@ class SpanEntry implements Comparable<SpanEntry> {
 
     SpanEntry(String name, String conventionClass, String nameFromConventionClass, String enclosingClass, String enumName, String description, String prefix,
             Collection<KeyValueEntry> tagKeys, Collection<KeyValueEntry> additionalKeyNames, Collection<KeyValueEntry> events, Map.Entry<String, String> overridesDefaultSpanFrom) {
-        Assert.hasText(description, "Span description must not be empty");
+        Assert.hasText(description, "Span javadoc description must not be empty");
         this.conventionClass = conventionClass;
         this.nameFromConventionClass = nameFromConventionClass;
         this.name = name;


### PR DESCRIPTION
I noticed maven build doesn't stop when an exception happened while maven-exec-plugin calling the `DocsFromSources`.

It simply logs a severe message but build continues.

Example output:
```
[INFO] --- exec-maven-plugin:1.6.0:java (generate-tracing-metadata) @ datasource-micrometer-docs ---
Aug 23, 2022 10:27:59 PM io.micrometer.docs.commons.ParsingUtils readClassValue
WARNING: Statement [class org.jboss.forge.roaster._shade.org.eclipse.jdt.core.dom.ReturnStatement] is not a method invocation.
Aug 23, 2022 10:27:59 PM io.micrometer.docs.spans.SpanSearchingFileVisitor visitFile
SEVERE: Failed to parse file [/Users/ttsuyukubo/repo/spring/datasource-micrometer/datasource-micrometer/src/main/java/net/ttddyy/observation/tracing/JdbcObservation.java] due to an error
java.lang.IllegalArgumentException: Span description must not be empty
	at io.micrometer.docs.commons.utils.Assert.hasText(Assert.java:22)
	at io.micrometer.docs.spans.SpanEntry.<init>(SpanEntry.java:59)
	at io.micrometer.docs.spans.SpanSearchingFileVisitor.parseSpan(SpanSearchingFileVisitor.java:219)
	at io.micrometer.docs.spans.SpanSearchingFileVisitor.visitFile(SpanSearchingFileVisitor.java:88)
	at io.micrometer.docs.spans.SpanSearchingFileVisitor.visitFile(SpanSearchingFileVisitor.java:52)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2811)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2882)
	at io.micrometer.docs.spans.DocsFromSources.generate(DocsFromSources.java:61)
	at io.micrometer.docs.spans.DocsFromSources.main(DocsFromSources.java:52)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:282)
	at java.base/java.lang.Thread.run(Thread.java:833)

... build continues ....
```

This is because `MetricSearchingFileVisitor` returns `FileVisitResult.CONTINUE` when an error occurred.

This PR changes to throw `IOException` instead of log and continue; so that, a failure in `DocsFromSources` bubbles up to fail the maven plugin execution, then fails the build.

Also, when `description` is missing, the error message says _"~ description must not be empty"_. Initially, I thought there is a `getDescription()` on the enum, but by looking at the code, it meant the javadoc on the enum. So, added `javadoc` to the error message to make it clear.

