### PR TITLE
Improve conversion of javadoc with html/taglets to asciidoc

### DIFF
--- a/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/ParsingUtils.java
+++ b/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/ParsingUtils.java
@@ -34,6 +34,7 @@ import io.micrometer.common.docs.KeyName;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import io.micrometer.docs.commons.utils.AsciidocUtils;
 import io.micrometer.observation.ObservationConvention;
 import org.jboss.forge.roaster.Internal;
 import org.jboss.forge.roaster.Roaster;
@@ -89,7 +90,7 @@ public class ParsingUtils {
         }
         for (EnumConstantSource enumConstant : myEnum.getEnumConstants()) {
             String keyValue = enumKeyValue(enumConstant, methodName);
-            keyValues.add(new KeyValueEntry(keyValue, enumConstant.getJavaDoc().getText()));
+            keyValues.add(new KeyValueEntry(keyValue, AsciidocUtils.javadocToAsciidoc(enumConstant.getJavaDoc())));
         }
     }
 

--- a/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/utils/AsciidocUtils.java
+++ b/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/utils/AsciidocUtils.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.docs.commons.utils;
+
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import io.micrometer.docs.commons.ObservationConventionEntry;
+import org.jboss.forge.roaster._shade.org.eclipse.jdt.core.dom.Javadoc;
+import org.jboss.forge.roaster._shade.org.eclipse.jdt.core.dom.TagElement;
+import org.jboss.forge.roaster._shade.org.eclipse.jdt.core.dom.TextElement;
+import org.jboss.forge.roaster.model.source.JavaDocSource;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Utilities to parse javadoc fragments in various form (String, modelling objects) to asciidoc strings.
+ */
+public class AsciidocUtils {
+
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(ObservationConventionEntry.class);
+
+    private static final String NEWLINE = System.lineSeparator();
+    private static final String LINE_BREAK = " +" + NEWLINE;
+    private static final String PARAGRAPH_BREAK = NEWLINE + NEWLINE;
+
+    private static final Pattern NEWLINE_PATTERN = Pattern.compile("\\R");
+
+    public static final String simpleHtmlToAsciidoc(String line, boolean assumeLiOrdered) {
+        String asciidoc = line
+                .replaceAll("<p/?>", PARAGRAPH_BREAK)
+                .replaceAll("<br/?>", LINE_BREAK)
+                .replaceAll("<strong>", PARAGRAPH_BREAK + "IMPORTANT: ")
+                .replaceAll("</strong>\\h+", PARAGRAPH_BREAK)
+                .replaceAll("</?b>", "*")
+                .replaceAll("</?i>", "_")
+                .replaceAll("<ul>", NEWLINE)
+                .replaceAll("<ol>", NEWLINE)
+                .replaceAll("</[uo]l>", NEWLINE)
+                .replaceAll("<li>", NEWLINE + (assumeLiOrdered ? " 1. " : " - "));
+        //strip all other tags (closing tags, unknown tags)
+        return asciidoc.replaceAll("<[^<>]*>", "");
+    }
+
+    public static final String simpleTagletToAsciidoc(String tagletName, List<?> tagletFragments) {
+        if ("@code".equals(tagletName) || "@value".equals(tagletName)) {
+            return tagletFragments
+                    .stream()
+                    .map(o -> o.toString().trim())
+                    .collect(Collectors.joining(" ", "`", "`"));
+        }
+        if ("@link".equals(tagletName) || "@linkplain".equals(tagletName)) {
+            Stream<String> stream = tagletFragments
+                    .stream()
+                    .map(o -> o.toString().trim());
+
+            if (tagletFragments.size() > 1)
+                return stream
+                        .skip(1)
+                        .collect(Collectors.joining(" "));
+            return stream
+                    .collect(Collectors.joining(" ", "`", "`"));
+        }
+        //render the full taglet as an inline code block
+        return Stream.concat(
+                        Stream.of(tagletName),
+                        tagletFragments.stream().map(o -> o.toString().trim())
+                )
+                .collect(Collectors.joining(" ", "`{", "}`"));
+    }
+
+    public static final String javadocToAsciidoc(JavaDocSource<?> javadoc) {
+        Object internal = javadoc.getInternal();
+        if (!(internal instanceof Javadoc)) {
+            return javadoc.getText();
+        }
+        Javadoc internalJavadoc = (Javadoc) internal;
+        @SuppressWarnings("unchecked")
+        List<TagElement> tagList = internalJavadoc.tags();
+        StringBuilder text = new StringBuilder();
+
+        boolean openedOrderedList = false;
+        for (TagElement tagElement : tagList) {
+            //only consider the javadoc description
+            if (tagElement.getTagName() != null)
+                continue;
+            for (Object fragment: tagElement.fragments()) {
+                //ignored: SimpleName
+                if (fragment instanceof TextElement) {
+                    TextElement textElement = (TextElement) fragment;
+                    String line = textElement.getText();
+                    //inline taglets will be separate fragments. we only care for embedded HTML subset
+                    if (line.contains("<") && line.contains(">")) {
+                        //only reset the li type when explicitly encountering an ol or ul.
+                        //note ol takes precedence, and this doesn't really work with nested ol/ul combinations.
+                        if (line.contains("<ul>")) {
+                            openedOrderedList = false;
+                        }
+                        if (line.contains("<ol>")) {
+                            openedOrderedList = true;
+                        }
+
+                        text.append(simpleHtmlToAsciidoc(line, openedOrderedList));
+                    }
+                    else {
+                        //we append a space at the end so that javadoc linebreaks in the middle of a simple text translate to a space
+                        text.append(line).append(' ');
+                    }
+                }
+                else if (fragment instanceof TagElement) {
+                    TagElement tagFragment = (TagElement) fragment;
+                    text.append(simpleTagletToAsciidoc(tagFragment.getTagName(), tagFragment.fragments()));
+                }
+                else {
+                    LOGGER.debug("dropped fragment during javadoc to asciidoc parsing: %s", tagElement);
+                }
+            }
+        }
+        //second pass on each line to trim undesirable spaces
+        String trimmed = NEWLINE_PATTERN
+                .splitAsStream(text)
+                .map(line -> line
+                        // we don't want multiple spaces in a row
+                        .replaceAll("\\h\\h+", " ")
+                        //we don't want trailing whitespaces, trim() doesn't work because we do want leading space when relevant
+                        .replaceAll("\\h+$", ""))
+                .collect(Collectors.joining(System.lineSeparator()));
+        return trimmed;
+    }
+}

--- a/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricEntry.java
+++ b/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricEntry.java
@@ -132,7 +132,10 @@ class MetricEntry implements Comparable<MetricEntry> {
                 .append("[[").append(metricDisplayName).append("]]\n")
                 .append("==== ")
                 .append(displayName)
-                .append("\n\n> ").append(description).append("\n\n")
+                //use the quote block style to correctly render asciidoc inside the quote
+                .append("\n\n____\n")
+                .append(description)
+                .append("\n____\n\n")
                 .append("**Metric name** ").append(name());
         if (this.name.contains("%s")) {
             text.append(" - since it contains `%s`, the name is dynamic and will be resolved at runtime.");
@@ -149,12 +152,18 @@ class MetricEntry implements Comparable<MetricEntry> {
             text.append("\n\nIMPORTANT: All tags must be prefixed with `").append(this.prefix).append("` prefix!");
         }
         if (!lowCardinalityKeyNames.isEmpty()) {
-            text.append("\n\n.Low cardinality Keys\n|===\n|Name | Description\n")
+            text.append("\n\n.Low cardinality Keys")
+                    //we use a,a column types to ensure nested asciidoc is rendered
+                    .append("\n[cols=\"a,a\"]")
+                    .append("\n|===\n|Name | Description\n")
                     .append(this.lowCardinalityKeyNames.stream().map(KeyValueEntry::toString).collect(Collectors.joining("\n")))
                     .append("\n|===");
         }
         if (!highCardinalityKeyNames.isEmpty()) {
-            text.append("\n\n.High cardinality Keys\n|===\n|Name | Description\n")
+            text.append("\n\n.High cardinality Keys")
+                    //we use a,a column types to ensure nested asciidoc is rendered
+                    .append("\n[cols=\"a,a\"]")
+                    .append("\n|===\n|Name | Description\n")
                     .append(this.highCardinalityKeyNames.stream().map(KeyValueEntry::toString).collect(Collectors.joining("\n")))
                     .append("\n|===");
         }

--- a/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricSearchingFileVisitor.java
+++ b/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricSearchingFileVisitor.java
@@ -42,6 +42,7 @@ import io.micrometer.core.instrument.docs.DocumentedMeter;
 import io.micrometer.docs.commons.KeyValueEntry;
 import io.micrometer.docs.commons.ObservationConventionEntry;
 import io.micrometer.docs.commons.ParsingUtils;
+import io.micrometer.docs.commons.utils.AsciidocUtils;
 import io.micrometer.observation.GlobalObservationConvention;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
@@ -194,7 +195,7 @@ class MetricSearchingFileVisitor extends SimpleFileVisitor<Path> {
             return null;
         }
         String name = "";
-        String description = enumConstant.getJavaDoc().getText();
+        String description = AsciidocUtils.javadocToAsciidoc(enumConstant.getJavaDoc());
         String prefix = "";
         String baseUnit = "";
         Meter.Type type = Meter.Type.TIMER;

--- a/micrometer-docs-generator-metrics/src/test/java/io/micrometer/docs/metrics/DocsFromSourcesTests.java
+++ b/micrometer-docs-generator-metrics/src/test/java/io/micrometer/docs/metrics/DocsFromSourcesTests.java
@@ -31,10 +31,14 @@ class DocsFromSourcesTests {
         File root = new File(".");
         File output = new File(root, "build");
 
-        new DocsFromSources(root, Pattern.compile(".*"), output).generate();
+        //FIXME consider isolating classes relevant to this test into their own package and use that as source root
+        //for now only consider the java classes at the root of package io.micrometer.docs.metrics
+        File sourceRoot = new File(root, "src/test");
+        new DocsFromSources(sourceRoot, Pattern.compile(".*/docs/metrics/[a-zA-Z]+\\.java"), output).generate();
 
         BDDAssertions.then(new String(Files.readAllBytes(new File(output, "_metrics.adoc").toPath())))
-                .contains("==== Async Annotation").contains("> Observation that wraps a")
+                .contains("==== Async Annotation")
+                .contains("____" + System.lineSeparator() + "Observation that wraps a")
                 .contains("**Metric name** `%s` - since").contains("Fully qualified name of")
                 .contains("|`class`|Class name where a method got annotated with @Async.")
                 .contains("|`class2`|Class name where a method got annotated.")
@@ -53,7 +57,8 @@ class DocsFromSourcesTests {
                 .contains("[[observability-metrics-events-having-observation-foo-stop]]")
                 .contains("===== Events Having Observation - foo stop")
                 .contains("> Stop event.")
-                .contains("**Metric name** `foo.stop`. **Type** `counter`.");
+                .contains("**Metric name** `foo.stop`. **Type** `counter`.")
+                .doesNotContain("docs.metrics.usecases"); //smoke test that usecases have been excluded
     }
 
 }

--- a/micrometer-docs-generator-metrics/src/test/java/io/micrometer/docs/metrics/usecases/sanitizing/ComplexJavadocTest.java
+++ b/micrometer-docs-generator-metrics/src/test/java/io/micrometer/docs/metrics/usecases/sanitizing/ComplexJavadocTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.docs.metrics.usecases.sanitizing;
+
+
+import io.micrometer.docs.metrics.DocsFromSources;
+import org.assertj.core.api.BDDAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.regex.Pattern;
+
+class ComplexJavadocTest {
+
+    @Test
+    void should_sanitize_meter_and_tag_javadocs() {
+        File sourceRoot = new File("src/test/java/io/micrometer/docs/metrics/usecases/sanitizing");
+        File output = new File( "./build");
+
+        new DocsFromSources(sourceRoot, Pattern.compile(".*"), output).generate();
+
+        BDDAssertions.then(new File(output, "_metrics.adoc"))
+                .hasSameTextualContentAs(new File(getClass().getResource("/expected-sanitizing.adoc").getFile()));
+    }
+}

--- a/micrometer-docs-generator-metrics/src/test/java/io/micrometer/docs/metrics/usecases/sanitizing/WithComplexJavadocDocumentedMeter.java
+++ b/micrometer-docs-generator-metrics/src/test/java/io/micrometer/docs/metrics/usecases/sanitizing/WithComplexJavadocDocumentedMeter.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.docs.metrics.usecases.sanitizing;
+
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.docs.DocumentedMeter;
+
+enum WithComplexJavadocDocumentedMeter implements DocumentedMeter {
+
+    /**
+     * This javadoc includes sanitized HTML elements and should result in multi-line output,
+     * except when a line is just there for wrapping like this one.
+     * <p>
+     * A paragraph.
+     * </p>
+     * <p>
+     * An unclosed paragraph.
+     * <br>
+     * An unclosed BR.
+     * <br/>
+     * A closed in single tag BR.
+     * <ul>
+     *     <li>it also contains</li>
+     *     <li>an unordered list</li>
+     * </ul>
+     * <strong>This is a sentence with <b>bold</b> and <i>italics</i> inside a strong tag.</strong>
+     *
+     * @return nothing
+     * @param none no parameter
+     */
+    HTML {
+        @Override
+        public String getName() {
+            return "html";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.TIMER;
+        }
+    },
+
+    /**
+     * This javadoc includes sanitized taglets elements which should all result in a single line:
+     * This is code: {@code someCode}.
+     * This is a simple link: {@linkplain #HTML}.
+     * This is a complex link with alias text: {@link io.micrometer.docs.commons.utils.AsciidocUtils#simpleHtmlToAsciidoc(String, boolean) some custom alias}.
+     */
+    TAGLETS {
+        @Override
+        public String getName() {
+            return "taglets";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.TIMER;
+        }
+    },
+
+    /**
+     * Single line with<br/>inline new line then an admonition.<strong>This is an admonition with *bold* and _italics_.</strong> This text is not part of the admonition.
+     */
+    INLINE_HTML_TAGS {
+        @Override
+        public String getName() {
+            return "inline_html_tags";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.TIMER;
+        }
+    },
+
+    /**
+     * This one demonstrates javadoc extraction and sanitization in tags.
+     */
+    WITH_TAGS {
+        @Override
+        public String getName() {
+            return "tags";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.TIMER;
+        }
+
+        @Override
+        public KeyName[] getKeyNames() {
+            return ComplexJavadocTags.values();
+        }
+    };
+
+    enum ComplexJavadocTags implements KeyName {
+
+        /**
+         * This tag javadoc includes sanitized HTML elements and should result in multi-line output:
+         * <p>
+         * A paragraph.
+         * </p>
+         * <p>
+         * An unclosed paragraph.
+         * <br>
+         * An unclosed BR.
+         * <br/>
+         * A closed in single tag BR.
+         * <ul>
+         *     <li>it also contains</li>
+         *     <li>an unordered list</li>
+         * </ul>
+         */
+        TAG_HTML {
+            @Override
+            public String asString() {
+                return "class";
+            }
+        },
+
+        /**
+         * This tag javadoc includes sanitized taglets elements which should all result in a single line:
+         * This is code: {@code someCode}.
+         * This is a simple link: {@link #HTML}.
+         * This is a link with alias text: {@link #HTML alias}.
+         */
+        TAG_TAGLETS {
+            @Override
+            public String asString() {
+                return "method";
+            }
+        }
+
+    }
+
+}

--- a/micrometer-docs-generator-metrics/src/test/resources/expected-sanitizing.adoc
+++ b/micrometer-docs-generator-metrics/src/test/resources/expected-sanitizing.adoc
@@ -1,0 +1,83 @@
+[[observability-metrics]]
+=== Observability - Metrics
+
+Below you can find a list of all samples declared by this project.
+
+[[observability-metrics-html]]
+==== Html
+
+____
+This javadoc includes sanitized HTML elements and should result in multi-line output, except when a line is just there for wrapping like this one.
+
+A paragraph.
+
+An unclosed paragraph. +
+An unclosed BR. +
+A closed in single tag BR.
+
+ - it also contains
+ - an unordered list
+
+
+IMPORTANT: This is a sentence with *bold* and _italics_ inside a strong tag.
+____
+
+**Metric name** `html`. **Type** `timer` and **base unit** `seconds`.
+
+Fully qualified name of the enclosing class `io.micrometer.docs.metrics.usecases.sanitizing.WithComplexJavadocDocumentedMeter`.
+
+[[observability-metrics-inline-html-tags]]
+==== Inline Html Tags
+
+____
+Single line with +
+inline new line then an admonition.
+
+IMPORTANT: This is an admonition with *bold* and _italics_.
+
+This text is not part of the admonition.
+____
+
+**Metric name** `inline_html_tags`. **Type** `timer` and **base unit** `seconds`.
+
+Fully qualified name of the enclosing class `io.micrometer.docs.metrics.usecases.sanitizing.WithComplexJavadocDocumentedMeter`.
+
+[[observability-metrics-taglets]]
+==== Taglets
+
+____
+This javadoc includes sanitized taglets elements which should all result in a single line: This is code: `someCode`. This is a simple link: `#HTML`. This is a complex link with alias text: some custom alias.
+____
+
+**Metric name** `taglets`. **Type** `timer` and **base unit** `seconds`.
+
+Fully qualified name of the enclosing class `io.micrometer.docs.metrics.usecases.sanitizing.WithComplexJavadocDocumentedMeter`.
+
+[[observability-metrics-with-tags]]
+==== With Tags
+
+____
+This one demonstrates javadoc extraction and sanitization in tags.
+____
+
+**Metric name** `tags`. **Type** `timer` and **base unit** `seconds`.
+
+Fully qualified name of the enclosing class `io.micrometer.docs.metrics.usecases.sanitizing.WithComplexJavadocDocumentedMeter`.
+
+.Low cardinality Keys
+[cols="a,a"]
+|===
+|Name | Description
+|`class`|This tag javadoc includes sanitized HTML elements and should result in multi-line output:
+
+A paragraph.
+
+An unclosed paragraph. +
+An unclosed BR. +
+A closed in single tag BR.
+
+ - it also contains
+ - an unordered list
+|`method`|This tag javadoc includes sanitized taglets elements which should all result in a single line: This is code: `someCode`. This is a simple link: `#HTML`. This is a link with alias text: alias.
+|===
+

--- a/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/SpanSearchingFileVisitor.java
+++ b/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/SpanSearchingFileVisitor.java
@@ -40,6 +40,7 @@ import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.docs.commons.KeyValueEntry;
 import io.micrometer.docs.commons.ObservationConventionEntry;
 import io.micrometer.docs.commons.ParsingUtils;
+import io.micrometer.docs.commons.utils.AsciidocUtils;
 import io.micrometer.observation.GlobalObservationConvention;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
@@ -207,7 +208,7 @@ class SpanSearchingFileVisitor extends SimpleFileVisitor<Path> {
         }
         String name = "";
         String contextualName = null;
-        String description = enumConstant.getJavaDoc().getText();
+        String description = AsciidocUtils.javadocToAsciidoc(enumConstant.getJavaDoc());
         String prefix = "";
         Collection<KeyValueEntry> tags = new TreeSet<>();
         Collection<KeyValueEntry> additionalKeyNames = new TreeSet<>();


### PR DESCRIPTION
This commit attempts to fix the generated asciidoc for javadoc blocks
that are not trivial:

A custom parsing of Roaster `getJavadoc()` model is used instead of
`getText()`/`getFullText()` to avoid mangling the original javadoc.
We attempt to convert a simple subset of HTML tags to their asciidoc
equivalents and to convert inline taglets to a relevant asciidoc
representation if any.

For HTML, we convert:
 - `p`, `br`, `b` and `i` to their direct equivalents
 - `strong` tags (including inline) to an `IMPORTANT:` admonition
 - `ul`/`ol` lists and their `li` elements in a best effort fashion

In case an `ol` is detected we have to turn ALL `li` to asciidoc
ordered list elements.

All other unknown HTML tags are removed but their node content is kept.

For taglets:
 - `@code` and `@value` taglets have their content turned into inline
  code blocks
 - `@link` and `@linkplain` taglets consider whether an alias text is
  provided. If so, only the alias text is provided in the asciidoc.
  If not, the target of the link is provided in the asciidoc as an
  inline code block.
 - unknown taglets are copied as an inline code block

Additionally, in order to ensure these asciidoc javadoc conversions are
correctly rendered in the output file, this commit polishes the syntax
of quotes and tables:
 - the `____` block style for quote is used instead of a single `>`
 - column format instruction `[cols="a,a"]` is used for tables

Fixes #21.