### PR TITLE
Add a map to KeyValueEntry to store extra attributes

### DIFF
--- a/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/KeyValueEntry.java
+++ b/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/KeyValueEntry.java
@@ -16,17 +16,33 @@
 
 package io.micrometer.docs.commons;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import org.jboss.forge.roaster.model.source.EnumConstantSource;
+
+/**
+ * Hold Key and Value type of information.
+ * For example, it is used to hold the data of {@link KeyName}, {@code EventValue}, and {@link Observation.Event}.
+ * Additionally, each entry can have map based extra attributes.
+ */
 public class KeyValueEntry implements Comparable<KeyValueEntry> {
 
     private final String name;
 
     private final String description;
 
-    public KeyValueEntry(String name, String description) {
+    private final Map<String, String> extra = new HashMap<>();
+
+    public KeyValueEntry(String name, String description, Map<String, String> extra) {
         this.name = name;
         this.description = description;
+        this.extra.putAll(extra);
     }
 
     @Override
@@ -37,13 +53,13 @@ public class KeyValueEntry implements Comparable<KeyValueEntry> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        KeyValueEntry tag = (KeyValueEntry) o;
-        return Objects.equals(name, tag.name) && Objects.equals(description, tag.description);
+        KeyValueEntry that = (KeyValueEntry) o;
+        return Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(extra, that.extra);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description);
+        return Objects.hash(name, description, extra);
     }
 
     @Override
@@ -71,4 +87,17 @@ public class KeyValueEntry implements Comparable<KeyValueEntry> {
     public String getDescription() {
         return description;
     }
+
+    public Map<String, String> getExtra() {
+        return this.extra;
+    }
+
+    /**
+     * Extract extra attribute information from the enum.
+     */
+    @FunctionalInterface
+    public interface ExtraAttributesExtractor extends Function<EnumConstantSource, Map<String, String>> {
+        ExtraAttributesExtractor EMPTY = (myEnum) -> Collections.emptyMap();
+    }
+
 }

--- a/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricSearchingFileVisitor.java
+++ b/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricSearchingFileVisitor.java
@@ -40,6 +40,7 @@ import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.docs.MeterDocumentation;
 import io.micrometer.docs.commons.KeyValueEntry;
+import io.micrometer.docs.commons.KeyValueEntry.ExtraAttributesExtractor;
 import io.micrometer.docs.commons.ObservationConventionEntry;
 import io.micrometer.docs.commons.ParsingUtils;
 import io.micrometer.docs.commons.utils.AsciidocUtils;
@@ -216,17 +217,17 @@ class MetricSearchingFileVisitor extends SimpleFileVisitor<Path> {
                 name = ParsingUtils.readStringReturnValue(methodDeclaration);
             }
             else if ("getKeyNames".equals(methodName)) {
-                lowCardinalityTags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class));
+                lowCardinalityTags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class, ExtraAttributesExtractor.EMPTY));
             }
             else if ("getDefaultConvention".equals(methodName)) {
                 conventionClass = ParsingUtils.readClass(methodDeclaration);
                 nameFromConventionClass = ParsingUtils.tryToReadStringReturnValue(file, conventionClass);
             }
             else if ("getLowCardinalityKeyNames".equals(methodName) || "asString".equals(methodName)) {
-                lowCardinalityTags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class));
+                lowCardinalityTags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class, ExtraAttributesExtractor.EMPTY));
             }
             else if ("getHighCardinalityKeyNames".equals(methodName)) {
-                highCardinalityTags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class));
+                highCardinalityTags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class, ExtraAttributesExtractor.EMPTY));
             }
             else if ("getPrefix".equals(methodName)) {
                 prefix = ParsingUtils.readStringReturnValue(methodDeclaration);
@@ -244,7 +245,7 @@ class MetricSearchingFileVisitor extends SimpleFileVisitor<Path> {
                 overridesDefaultMetricFrom = ParsingUtils.readClassToEnum(methodDeclaration);
             }
             else if ("getEvents".equals(methodName)) {
-                Collection<KeyValueEntry> entries = ParsingUtils.keyValueEntries(myEnum, methodDeclaration, Observation.Event.class, "getName");
+                Collection<KeyValueEntry> entries = ParsingUtils.keyValueEntries(myEnum, methodDeclaration, Observation.Event.class, "getName", ExtraAttributesExtractor.EMPTY);
                 Collection<MetricEntry> counters = entries.stream().map(k -> new MetricEntry(k.getName(), null, null, myEnum.getCanonicalName(), enumConstant.getName(), k.getDescription(), null, null, Meter.Type.COUNTER, new TreeSet<>(), new TreeSet<>(), null, new TreeSet<>())).collect(Collectors.toList());
                 events.addAll(counters);
             }

--- a/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/SpanSearchingFileVisitor.java
+++ b/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/SpanSearchingFileVisitor.java
@@ -38,6 +38,7 @@ import io.micrometer.common.docs.KeyName;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.docs.commons.KeyValueEntry;
+import io.micrometer.docs.commons.KeyValueEntry.ExtraAttributesExtractor;
 import io.micrometer.docs.commons.ObservationConventionEntry;
 import io.micrometer.docs.commons.ParsingUtils;
 import io.micrometer.docs.commons.utils.AsciidocUtils;
@@ -234,22 +235,22 @@ class SpanSearchingFileVisitor extends SimpleFileVisitor<Path> {
                 contextualName = ParsingUtils.readStringReturnValue(methodDeclaration);
             }
             else if ("getKeyNames".equals(methodName)) {
-                tags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class));
+                tags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class, ExtraAttributesExtractor.EMPTY));
             }
             else if ("getLowCardinalityKeyNames".equals(methodName)) {
-                tags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class));
+                tags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class, ExtraAttributesExtractor.EMPTY));
             }
             else if ("getHighCardinalityKeyNames".equals(methodName)) {
-                tags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class));
+                tags.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class, ExtraAttributesExtractor.EMPTY));
             }
             else if ("getAdditionalKeyNames".equals(methodName)) {
-                additionalKeyNames.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class));
+                additionalKeyNames.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, KeyName.class, ExtraAttributesExtractor.EMPTY));
             }
             else if ("getEvents".equals(methodName)) {
                 if (methodDeclaration.getReturnType2().toString().contains("EventValue")) {
-                    events.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, EventValue.class));
+                    events.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, EventValue.class, ExtraAttributesExtractor.EMPTY));
                 } else {
-                    events.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, Observation.Event.class, "getContextualName"));
+                    events.addAll(ParsingUtils.keyValueEntries(myEnum, methodDeclaration, Observation.Event.class, "getContextualName", ExtraAttributesExtractor.EMPTY));
                 }
             }
             else if ("getPrefix".equals(methodName)) {


### PR DESCRIPTION
`ParsingUtils.keyValueEntries` is used not only for `KeyName` but also `EventValue` and `Observation.Event` in spans.
If we add `required` information to `KeyName`, it is not easy to adapt the `required` semantics to the `KeyValueEntry` directly.

This PR, instead of directly adding some specific fields, adds a map to the `KeyValueEntry`. The map holds extra attributes on the entry.
Also, the creation of `KeyValueEntry` takes a function to supply the extra attributes. (Currently, it gets empty attributes populated.)

For example, if we add `required` information to tags(`KeyName`), the map could hold the `required` attribute. When the `KeyValueEntry` is created, the attributes provider can extract the `required` information from the tags enum, then populate to the map. Since `required` is only for tags, span events don't need to change at all.
When writing output document, based on the type of entry, caller should retrieve extra attribute information from the added map, then write out the document.
