### PR TITLE
Look up interfaces to resolve ObservationConvention#getName()

### DIFF
--- a/micrometer-docs-generator-spans/src/test/java/io/micrometer/docs/spans/conventions/AnnotationSpan.java
+++ b/micrometer-docs-generator-spans/src/test/java/io/micrometer/docs/spans/conventions/AnnotationSpan.java
@@ -84,6 +84,27 @@ enum AnnotationSpan implements ObservationDocumentation {
             return Tags2.values();
         }
 
+    },
+
+    /**
+     * Observation with interface that implements getName method.
+     */
+    CONCRETE_CONVENTION {
+        @Override
+        public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+            return UseInterfaceObservationConvention.class;
+        }
+
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return Tags.values();
+        }
+
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return Tags2.values();
+        }
+
     };
 
     static class NestedConvention implements ObservationConvention<Observation.Context> {

--- a/micrometer-docs-generator-spans/src/test/java/io/micrometer/docs/spans/conventions/ConventionsTests.java
+++ b/micrometer-docs-generator-spans/src/test/java/io/micrometer/docs/spans/conventions/ConventionsTests.java
@@ -38,6 +38,7 @@ class ConventionsTests {
         BDDAssertions.then(new String(Files.readAllBytes(new File(output, "_spans.adoc").toPath())))
                 .contains("**Span name** `nested convention` (defined by convention class `io.micrometer.docs.spans.conventions.AnnotationSpan$NestedConvention`)")
                 .contains("**Span name** `foo` (defined by convention class `io.micrometer.docs.spans.conventions.PublicObservationConvention`)")
+                .contains("**Span name** `foo-iface` (defined by convention class `io.micrometer.docs.spans.conventions.UseInterfaceObservationConvention`)")
                 .contains("**Span name** Unable to resolve the name - please check the convention class `io.micrometer.docs.spans.conventions.DynamicObservationConvention` for more details.");
     }
 

--- a/micrometer-docs-generator-spans/src/test/java/io/micrometer/docs/spans/conventions/ObservationConventionInterface.java
+++ b/micrometer-docs-generator-spans/src/test/java/io/micrometer/docs/spans/conventions/ObservationConventionInterface.java
@@ -1,0 +1,19 @@
+package io.micrometer.docs.spans.conventions;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Context;
+import io.micrometer.observation.ObservationConvention;
+
+public interface ObservationConventionInterface extends ObservationConvention<Context> {
+
+    @Override
+    default String getName() {
+        return "foo-iface";
+    }
+
+    @Override
+    default boolean supportsContext(Observation.Context context) {
+        return true;
+    }
+
+}

--- a/micrometer-docs-generator-spans/src/test/java/io/micrometer/docs/spans/conventions/UseInterfaceObservationConvention.java
+++ b/micrometer-docs-generator-spans/src/test/java/io/micrometer/docs/spans/conventions/UseInterfaceObservationConvention.java
@@ -1,0 +1,4 @@
+package io.micrometer.docs.spans.conventions;
+
+public class UseInterfaceObservationConvention implements ObservationConventionInterface {
+}


### PR DESCRIPTION
When specified `ObservationConvention` class does not implement `getName()` method, look for the method in implementing interfaces.