### PR TITLE
WIP: templating adoc with thymeleaf

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,7 @@
 def VERSIONS = [
 		'org.jboss.forge.roaster:roaster-api:2.22.3.Final', // last using jdk8
 		'org.jboss.forge.roaster:roaster-jdt:2.22.3.Final', // last using jdk8
+		'org.thymeleaf:thymeleaf:latest.release',
 
 		// logging
 		'ch.qos.logback:logback-classic:1.2.+',

--- a/micrometer-docs-generator-commons/build.gradle
+++ b/micrometer-docs-generator-commons/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	api 'org.jboss.forge.roaster:roaster-jdt'
 	api 'io.micrometer:micrometer-commons'
 	api 'io.micrometer:micrometer-observation'
+	api 'org.thymeleaf:thymeleaf'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter'
 	testImplementation 'org.assertj:assertj-core'

--- a/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/KeyValueEntry.java
+++ b/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/KeyValueEntry.java
@@ -71,4 +71,8 @@ public class KeyValueEntry implements Comparable<KeyValueEntry> {
     public String getDescription() {
         return description;
     }
+
+    public String getDisplayDescription() {
+        return description();
+    }
 }

--- a/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricEntry.java
+++ b/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricEntry.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import io.micrometer.core.instrument.Meter;
@@ -190,6 +191,19 @@ class MetricEntry implements Comparable<MetricEntry> {
         return text.toString();
     }
 
+    public String getTitleName() {
+        return getDisplayName().toLowerCase(Locale.ROOT).replace(" ", "-");
+    }
+
+    public String getDisplayName() {
+        return Arrays.stream(enumName.replace("_", " ").split(" "))
+                .map(s -> StringUtils.capitalize(s.toLowerCase(Locale.ROOT))).collect(Collectors.joining(" "));
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
     private String name() {
         if (StringUtils.hasText(this.name)) {
             return "`" + this.name + "`";
@@ -200,4 +214,45 @@ class MetricEntry implements Comparable<MetricEntry> {
         return "Unable to resolve the name - please check the convention class `" + this.conventionClass + "` for more details";
     }
 
+    public String getMetricName() {
+        return name();
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getDisplayType() {
+        return this.type.toString().toLowerCase(Locale.ROOT).replace("_", " ");
+    }
+
+    public String getBaseUnit() {
+        return this.baseUnit;
+    }
+
+    public String getEnclosingClass() {
+        return this.enclosingClass;
+    }
+
+    public String getPrefix() {
+        return this.prefix;
+    }
+
+    public TreeSet<KeyValueEntry> getLowCardinalityKeyNames() {
+        // Use TreeSet which is the originally passed collection type.
+        // Since thymeleaf differentiate list and set, concrete type is needed.
+        return new TreeSet<>(this.lowCardinalityKeyNames);
+    }
+
+    public TreeSet<KeyValueEntry> getHighCardinalityKeyNames() {
+        // Use TreeSet which is the originally passed collection type.
+        // Since thymeleaf differentiate list and set, concrete type is needed.
+        return new TreeSet<>(this.highCardinalityKeyNames);
+    }
+
+    public Collection<MetricEntry> getEvents() {
+        // Use TreeSet which is the originally passed collection type.
+        // Since thymeleaf differentiate list and set, concrete type is needed.
+        return new TreeSet<>(this.events);
+    }
 }

--- a/micrometer-docs-generator-metrics/src/main/resources/templates/metrics.adoc
+++ b/micrometer-docs-generator-metrics/src/main/resources/templates/metrics.adoc
@@ -1,0 +1,65 @@
+/*[- */
+  This is a thymeleaf template file for metrics documentation.
+/* -]*/
+[[[[observability-metrics]]]]
+=== Observability - Metrics
+
+Below you can find a list of all samples declared by this project.
+[# th:each="entry : ${entries}"]
+
+[[observability-metrics-[# th:utext="${entry.titleName}" /]]]
+==== [(${entry.displayName})]
+
+____
+[(${entry.description})]
+____
+
+
+**Metric name** [(${entry.metricName})]
+[(${#strings.contains(entry.name,'%s') ? " - since it contains `%s`, the name is dynamic and will be resolved at runtime." : "."})]
+**Type** `[(${entry.displayType})]` [(${#strings.isEmpty(entry.baseUnit)? "" : "and **base unit** `" + #strings.toLowerCase(entry.baseUnit) + "`"})].
+
+Fully qualified name of the enclosing class `[(${entry.enclosingClass})]`.
+
+[# th:if="${#strings.length(entry.prefix) > 0}"]
+IMPORTANT: All tags must be prefixed with `[(${entry.prefix})]` prefix!
+[/]
+
+[# th:if="${not #sets.isEmpty(entry.lowCardinalityKeyNames)}"]
+.Low cardinality Keys
+[cols="a,a"]
+|===
+|Name | Description
+  [# th:each="lowKey : ${entry.lowCardinalityKeyNames}"]
+|`[(${lowKey.name})]`|[(${lowKey.displayDescription})]
+  [/]
+|===
+[/]
+
+[# th:if="${not #sets.isEmpty(entry.highCardinalityKeyNames)}"]
+.High cardinality Keys
+[cols="a,a"]
+|===
+|Name | Description
+  [# th:each="highKey : ${entry.highCardinalityKeyNames}"]
+|`[(${highKey.name})]`|[(${highKey.displayDescription})]
+  [/]
+|===
+[/]
+
+[# th:if="${not #sets.isEmpty(entry.events)}"]
+Since, events were set on this documented entry, they will be converted to the following counters.
+  [# th:each="event : ${entry.events}"]
+    [# th:with="eventTitleName=${#strings.replace(event.name, '.', '-')}"]
+[[observability-metrics-[# th:utext="${entry.titleName} + ${eventTitleName}" /]]]
+===== [(${entry.displayName})] - [(${#strings.replace(event.name, '.', ' ')})]
+
+> [(${event.description})]
+
+**Metric name** `[(${eventTitleName})]`[(${#strings.contains(entry.name,'%s') ? " - since it contains `%s`, the name is dynamic and will be resolved at runtime." : "."})] **Type** `[(${event.displayType})]`.
+
+    [/]
+  [/]
+[/]
+
+[/]


### PR DESCRIPTION
Using thymeleaf TEXT mode, create templates for adoc file generation.

Due to [this issue](https://github.com/thymeleaf/thymeleaf/issues/774) in thymeleaf TEXT mode, a line with thymeleaf directives won't be removed. So, the generated adoc has more empty lines.
So far, I haven't noticed any differences in the final HTML from the generated adoc, even though it has more empty lines. Though, it might be a problem composing a proper adoc file later.


Currently, only metrics is converted.
