### PR TITLE
Use Handlebars for templating

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,7 @@
 def VERSIONS = [
 		'org.jboss.forge.roaster:roaster-api:2.22.3.Final', // last using jdk8
 		'org.jboss.forge.roaster:roaster-jdt:2.22.3.Final', // last using jdk8
+		'com.github.jknack:handlebars:latest.release',
 
 		// logging
 		'ch.qos.logback:logback-classic:1.2.+',

--- a/micrometer-docs-generator-commons/build.gradle
+++ b/micrometer-docs-generator-commons/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	api 'org.jboss.forge.roaster:roaster-jdt'
 	api 'io.micrometer:micrometer-commons'
 	api 'io.micrometer:micrometer-observation'
+	api 'com.github.jknack:handlebars'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter'
 	testImplementation 'org.assertj:assertj-core'

--- a/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/KeyValueEntry.java
+++ b/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/KeyValueEntry.java
@@ -71,4 +71,9 @@ public class KeyValueEntry implements Comparable<KeyValueEntry> {
     public String getDescription() {
         return description;
     }
+
+    public String getDisplayDescription() {
+        // TODO: use handlebar helper to compose the description
+        return description();
+    }
 }

--- a/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/ObservationConventionEntry.java
+++ b/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/ObservationConventionEntry.java
@@ -16,14 +16,6 @@
 
 package io.micrometer.docs.commons;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.docs.commons.utils.StringUtils;
@@ -52,6 +44,10 @@ public class ObservationConventionEntry implements Comparable<ObservationConvent
         return contextClassName;
     }
 
+    public Type getType() {
+        return this.type;
+    }
+
     @Override
     public int compareTo(ObservationConventionEntry o) {
         int compare = this.contextClassName.compareTo(o.contextClassName);
@@ -72,50 +68,4 @@ public class ObservationConventionEntry implements Comparable<ObservationConvent
         GLOBAL, LOCAL
     }
 
-    public static void saveEntriesAsAdocTableInAFile(Collection<ObservationConventionEntry> entries, File outputFile) throws IOException {
-        if (entries.isEmpty()) {
-            logger.debug("No ObservationConventions found - will not output anything");
-            return;
-        }
-
-        StringBuilder builder = new StringBuilder();
-        List<ObservationConventionEntry> global = entries.stream().filter(e -> e.type == Type.GLOBAL).collect(Collectors.toList());
-        List<ObservationConventionEntry> local = entries.stream().filter(e -> e.type == Type.LOCAL).collect(Collectors.toList());
-
-        Path output = outputFile.toPath();
-        logger.debug("======================================");
-        logger.debug("Summary of sources analysis for conventions");
-        logger.debug("Found [" + entries.size() + "] conventions");
-        logger.debug(
-                "Found [" + global.size() + "] GlobalObservationConvention implementations");
-        logger.debug(
-                "Found [" + local.size() + "] ObservationConvention implementations");
-
-        builder.append("[[observability-conventions]]\n")
-                .append("=== Observability - Conventions\n\n")
-                .append("Below you can find a list of all `GlobalObservabilityConventions` and `ObservabilityConventions` declared by this project.")
-                .append("\n\n");
-
-        if (!global.isEmpty()) {
-            builder.append(".GlobalObservationConvention implementations\n")
-                    .append("|===\n")
-                    .append("|GlobalObservationConvention Class Name | Applicable ObservationContext Class Name\n")
-                    .append(global.stream().map(e -> "|`" + e.getClassName() + "`|`" + e.contextClassName + "`").collect(Collectors.joining("\n")))
-                    .append("\n|===");
-
-            builder.append("\n\n");
-        }
-
-        // TODO: Duplication
-        if (!local.isEmpty()) {
-
-            builder.append(".ObservationConvention implementations\n")
-                    .append("|===\n")
-                    .append("|ObservationConvention Class Name | Applicable ObservationContext Class Name\n")
-                    .append(local.stream().map(e -> "|`" + e.getClassName() + "`|`" + e.contextClassName + "`").collect(Collectors.joining("\n")))
-                    .append("\n|===");
-        }
-
-        Files.write(output, builder.toString().getBytes());
-    }
 }

--- a/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/templates/ADocHelpers.java
+++ b/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/templates/ADocHelpers.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.docs.commons.templates;
+
+/**
+ * Helper source class for handlebars.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class ADocHelpers {
+
+    public static boolean isDynamic(String input) {
+        return input.contains("%s");
+    }
+
+}

--- a/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/templates/HandlebarsUtils.java
+++ b/micrometer-docs-generator-commons/src/main/java/io/micrometer/docs/commons/templates/HandlebarsUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.docs.commons.templates;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.helper.StringHelpers;
+import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
+import com.github.jknack.handlebars.io.CompositeTemplateLoader;
+import com.github.jknack.handlebars.io.FileTemplateLoader;
+import com.github.jknack.handlebars.io.TemplateLoader;
+
+/**
+ * Utility for {@link Handlebars}.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class HandlebarsUtils {
+
+    public static Handlebars createHandlebars() {
+        // specify default prefix and empty suffix. The empty suffix forces users to
+        // specify the full template file name. (e.g. foo.adoc.hbs)
+        ClassPathTemplateLoader classPathLoader = new ClassPathTemplateLoader(TemplateLoader.DEFAULT_PREFIX, "");
+        FileTemplateLoader fileLoader = new FileTemplateLoader(TemplateLoader.DEFAULT_PREFIX, "");
+        CompositeTemplateLoader compositeLoader = new CompositeTemplateLoader(classPathLoader, fileLoader);
+
+        Handlebars handlebars = new Handlebars(compositeLoader);
+        handlebars.registerHelpers(ADocHelpers.class);
+        StringHelpers.register(handlebars);
+
+        return handlebars;
+    }
+}

--- a/micrometer-docs-generator-commons/src/main/resources/templates/conventions.adoc.hbs
+++ b/micrometer-docs-generator-commons/src/main/resources/templates/conventions.adoc.hbs
@@ -1,0 +1,31 @@
+{{!
+    This is a handlebars template file for conventions documentation.
+~}}
+[[observability-conventions]]
+=== Observability - Conventions
+
+Below you can find a list of all `GlobalObservabilityConventions` and `ObservabilityConventions` declared by this project.
+
+{{~#each globals}}
+{{#if @first}}
+.GlobalObservationConvention implementations
+|===
+|GlobalObservationConvention Class Name | Applicable ObservationContext Class Name
+{{/if~}}
+|`{{this.className}}`|`{{this.contextClassName}}`
+{{#if @last~}}
+|===
+{{~/if}}
+{{~/each}}
+
+{{#each locals~}}
+{{#if @first~}}
+.ObservationConvention implementations
+|===
+|ObservationConvention Class Name | Applicable ObservationContext Class Name
+{{/if~}}
+|`{{this.className}}`|`{{this.contextClassName}}`
+{{#if @last~}}
+|===
+{{~/if}}
+{{~/each}}

--- a/micrometer-docs-generator-commons/src/test/java/io/micrometer/docs/commons/ObservationConventionEntryTests.java
+++ b/micrometer-docs-generator-commons/src/test/java/io/micrometer/docs/commons/ObservationConventionEntryTests.java
@@ -18,9 +18,13 @@ package io.micrometer.docs.commons;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import com.github.jknack.handlebars.Handlebars;
+import io.micrometer.docs.commons.templates.HandlebarsUtils;
 import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,11 +42,20 @@ class ObservationConventionEntryTests {
     void should_save_conventions_as_adoc_table() throws IOException {
         ObservationConventionEntry localEntry = new ObservationConventionEntry("foo.bar.LocalBaz", ObservationConventionEntry.Type.LOCAL, "Observation.Context");
         ObservationConventionEntry globalEntry = new ObservationConventionEntry("foo.bar.GlobalBaz", ObservationConventionEntry.Type.GLOBAL, "Foo");
-        File file = new File(this.output, "_success.adoc");
+        List<ObservationConventionEntry> globals = Collections.singletonList(globalEntry);
+        List<ObservationConventionEntry> locals = Collections.singletonList(localEntry);
 
-        ObservationConventionEntry.saveEntriesAsAdocTableInAFile(Arrays.asList(localEntry, globalEntry), file);
+        Handlebars handlebars = HandlebarsUtils.createHandlebars();
 
-        BDDAssertions.then(new String(Files.readAllBytes(file.toPath())))
+        Map<String, Object> map = new HashMap<>();
+        map.put("globals", globals);
+        map.put("locals", locals);
+
+        String template = "templates/conventions.adoc.hbs";
+
+        String result = handlebars.compile(template).apply(map);
+
+        BDDAssertions.then(result)
                 .contains("|`foo.bar.GlobalBaz`|`Foo`")
                 .contains("|`foo.bar.LocalBaz`|`Observation.Context`");
     }

--- a/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricEntry.java
+++ b/micrometer-docs-generator-metrics/src/main/java/io/micrometer/docs/metrics/MetricEntry.java
@@ -18,15 +18,14 @@ package io.micrometer.docs.metrics;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.docs.commons.KeyValueEntry;
 import io.micrometer.docs.commons.utils.Assert;
 import io.micrometer.docs.commons.utils.StringUtils;
@@ -123,73 +122,6 @@ class MetricEntry implements Comparable<MetricEntry> {
         return enumName.compareTo(o.enumName);
     }
 
-    @Override
-    public String toString() {
-        String displayName = Arrays.stream(enumName.replace("_", " ").split(" "))
-                .map(s -> StringUtils.capitalize(s.toLowerCase(Locale.ROOT))).collect(Collectors.joining(" "));
-        String metricDisplayName = "observability-metrics-" + displayName.toLowerCase(Locale.ROOT).replace(" ", "-");
-        StringBuilder text = new StringBuilder()
-                .append("[[").append(metricDisplayName).append("]]\n")
-                .append("==== ")
-                .append(displayName)
-                //use the quote block style to correctly render asciidoc inside the quote
-                .append("\n\n____\n")
-                .append(description)
-                .append("\n____\n\n")
-                .append("**Metric name** ").append(name());
-        if (this.name.contains("%s")) {
-            text.append(" - since it contains `%s`, the name is dynamic and will be resolved at runtime.");
-        }
-        else {
-            text.append(".");
-        }
-        text.append(" **Type** `").append(type.toString().toLowerCase(Locale.ROOT).replace("_", " "));
-        if (StringUtils.hasText(baseUnit)) {
-            text.append("` and **base unit** `").append(baseUnit.toLowerCase(Locale.ROOT));
-        }
-        text.append("`.").append("\n\n").append("Fully qualified name of the enclosing class `").append(this.enclosingClass).append("`.");
-        if (StringUtils.hasText(prefix)) {
-            text.append("\n\nIMPORTANT: All tags must be prefixed with `").append(this.prefix).append("` prefix!");
-        }
-        if (!lowCardinalityKeyNames.isEmpty()) {
-            text.append("\n\n.Low cardinality Keys")
-                    //we use a,a column types to ensure nested asciidoc is rendered
-                    .append("\n[cols=\"a,a\"]")
-                    .append("\n|===\n|Name | Description\n")
-                    .append(this.lowCardinalityKeyNames.stream().map(KeyValueEntry::toString).collect(Collectors.joining("\n")))
-                    .append("\n|===");
-        }
-        if (!highCardinalityKeyNames.isEmpty()) {
-            text.append("\n\n.High cardinality Keys")
-                    //we use a,a column types to ensure nested asciidoc is rendered
-                    .append("\n[cols=\"a,a\"]")
-                    .append("\n|===\n|Name | Description\n")
-                    .append(this.highCardinalityKeyNames.stream().map(KeyValueEntry::toString).collect(Collectors.joining("\n")))
-                    .append("\n|===");
-        }
-        if (!events.isEmpty()) {
-            text.append("\n\nSince, events were set on this documented entry, they will be converted to the following counters.\n\n");
-
-            events.forEach(metricEntry -> {
-                String counterName = metricEntry.name;
-                text.append("[[").append(metricDisplayName).append("-").append(counterName.replace(".", "-")).append("]]\n")
-                        .append("===== ")
-                        .append(displayName).append(" - ").append(counterName.replace(".", " "))
-                        .append("\n\n> ").append(metricEntry.description).append("\n\n")
-                        .append("**Metric name** `").append(counterName).append("`");
-                if (this.name.contains("%s")) {
-                    text.append(" - since it contains `%s`, the name is dynamic and will be resolved at runtime.");
-                }
-                else {
-                    text.append(".");
-                }
-                text.append(" **Type** `").append(metricEntry.type.toString().toLowerCase(Locale.ROOT).replace("_", " ")).append("`.\n\n");
-            });
-
-        }
-        return text.toString();
-    }
-
     private String name() {
         if (StringUtils.hasText(this.name)) {
             return "`" + this.name + "`";
@@ -200,4 +132,49 @@ class MetricEntry implements Comparable<MetricEntry> {
         return "Unable to resolve the name - please check the convention class `" + this.conventionClass + "` for more details";
     }
 
+    public String getDescription() {
+        return this.description;
+    }
+
+    public String getMetricName() {
+        // TODO: convert to handlebar helper
+        return name();
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getEnumName() {
+        return this.enumName;
+    }
+
+    public Type getType() {
+        return this.type;
+    }
+
+    public String getBaseUnit() {
+        return this.baseUnit;
+    }
+
+    public String getEnclosingClass() {
+        return this.enclosingClass;
+    }
+
+    public String getPrefix() {
+        return this.prefix;
+    }
+
+
+    public Collection<KeyValueEntry> getLowCardinalityKeyNames() {
+        return this.lowCardinalityKeyNames;
+    }
+
+    public Collection<KeyValueEntry> getHighCardinalityKeyNames() {
+        return this.highCardinalityKeyNames;
+    }
+
+    public Collection<MetricEntry> getEvents() {
+        return this.events;
+    }
 }

--- a/micrometer-docs-generator-metrics/src/main/resources/templates/metrics.adoc.hbs
+++ b/micrometer-docs-generator-metrics/src/main/resources/templates/metrics.adoc.hbs
@@ -1,0 +1,68 @@
+{{!
+    This is a handlebars template file for metrics documentation.
+~}}
+[[observability-metrics]]
+=== Observability - Metrics
+
+Below you can find a list of all metrics declared by this project.
+
+{{#each entries~}}
+[[observability-metrics-{{slugify (lower (replace enumName "_" " "))}}]]
+==== {{capitalize (lower (replace enumName "_" " "))}}
+
+____
+{{{description}}}
+____
+
+**Metric name** {{{metricName}}}{{#if (isDynamic name)}} - since it contains `%s`, the name is dynamic and will be resolved at runtime.
+{{~else}}.{{/if}} **Type** `{{replace (lower type) "_" " "}}`{{#if baseUnit}} and **base unit** `{{lower baseUnit}}`{{/if~}}.
+
+Fully qualified name of the enclosing class `{{enclosingClass}}`.
+
+{{#if prefix~}}
+IMPORTANT: All tags must be prefixed with `{{prefix}}` prefix!
+{{~/if}}
+
+{{#each lowCardinalityKeyNames~}}
+{{~#if @first~}}
+.Low cardinality Keys
+[cols="a,a"]
+|===
+|Name | Description
+{{~/if}}
+|`{{this.name}}`|{{{this.displayDescription}}}
+{{~#if @last}}
+|===
+{{~/if}}
+{{~/each}}
+
+{{#each highCardinalityKeyNames~}}
+{{~#if @first~}}
+.High cardinality Keys
+[cols="a,a"]
+|===
+|Name | Description
+{{~/if}}
+|`{{this.name}}`|{{{this.displayDescription}}}
+{{~#if @last}}
+|===
+{{~/if}}
+{{~/each}}
+
+{{#each events~}}
+{{~#if @first~}}
+Since, events were set on this documented entry, they will be converted to the following counters.
+{{/if}}
+[[observability-metrics-{{slugify (lower (replace this.enumName "_" " "))}}-{{replace this.name "." "-"}}]]
+===== {{capitalize (lower (replace this.enumName "_" " "))}} - {{replace this.name "." " "}}
+
+> {{{this.description}}}
+
+**Metric name** `{{{this.name}}}`{{#if (isDynamic this.name)~}}
+    - since it contains `%s`, the name is dynamic and will be resolved at runtime.
+    {{~else~}}
+    .
+{{~/if}} **Type** `{{replace (lower this.type) "_" " "}}`.
+{{/each}}
+
+{{~/each}}

--- a/micrometer-docs-generator-metrics/src/test/resources/expected-sanitizing.adoc
+++ b/micrometer-docs-generator-metrics/src/test/resources/expected-sanitizing.adoc
@@ -26,6 +26,12 @@ ____
 
 Fully qualified name of the enclosing class `io.micrometer.docs.metrics.usecases.sanitizing.WithComplexJavadocMeterDocumentation`.
 
+
+
+
+
+
+
 [[observability-metrics-inline-html-tags]]
 ==== Inline Html Tags
 
@@ -42,6 +48,12 @@ ____
 
 Fully qualified name of the enclosing class `io.micrometer.docs.metrics.usecases.sanitizing.WithComplexJavadocMeterDocumentation`.
 
+
+
+
+
+
+
 [[observability-metrics-taglets]]
 ==== Taglets
 
@@ -53,6 +65,12 @@ ____
 
 Fully qualified name of the enclosing class `io.micrometer.docs.metrics.usecases.sanitizing.WithComplexJavadocMeterDocumentation`.
 
+
+
+
+
+
+
 [[observability-metrics-with-tags]]
 ==== With Tags
 
@@ -63,6 +81,8 @@ ____
 **Metric name** `tags`. **Type** `timer` and **base unit** `seconds`.
 
 Fully qualified name of the enclosing class `io.micrometer.docs.metrics.usecases.sanitizing.WithComplexJavadocMeterDocumentation`.
+
+
 
 .Low cardinality Keys
 [cols="a,a"]
@@ -80,4 +100,7 @@ A closed in single tag BR.
  - an unordered list
 |`method`|This tag javadoc includes sanitized taglets elements which should all result in a single line: This is code: `someCode`. This is a simple link: `#HTML`. This is a link with alias text: alias.
 |===
+
+
+
 

--- a/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/SpanEntry.java
+++ b/micrometer-docs-generator-spans/src/main/java/io/micrometer/docs/spans/SpanEntry.java
@@ -114,37 +114,6 @@ class SpanEntry implements Comparable<SpanEntry> {
         return enumName.compareTo(o.enumName);
     }
 
-    @Override
-    public String toString() {
-        String displayName = Arrays.stream(enumName.replace("_", " ").split(" "))
-                .map(s -> StringUtils.capitalize(s.toLowerCase(Locale.ROOT))).collect(Collectors.joining(" "));
-        StringBuilder text = new StringBuilder()
-                .append("[[observability-spans-").append(displayName.toLowerCase(Locale.ROOT).replace(" ", "-")).append("]]\n")
-                .append("==== ")
-                .append(spanName())
-                .append("\n\n> ").append(description).append("\n\n")
-                .append("**Span name** ").append(name());
-        if (name.contains("%s")) {
-            text.append(" - since it contains `%s`, the name is dynamic and will be resolved at runtime.");
-        }
-        else {
-            text.append(".");
-        }
-        text.append("\n\n").append("Fully qualified name of the enclosing class `").append(this.enclosingClass).append("`.");
-        if (StringUtils.hasText(prefix)) {
-            text.append("\n\nIMPORTANT: All tags and event names must be prefixed with `").append(this.prefix).append("` prefix!");
-        }
-        if (!tagKeys.isEmpty()) {
-            text.append("\n\n.Tag Keys\n|===\n|Name | Description\n").append(this.tagKeys.stream().map(KeyValueEntry::toString).collect(Collectors.joining("\n")))
-                    .append("\n|===");
-        }
-        if (!events.isEmpty()) {
-            text.append("\n\n.Event Values\n|===\n|Name | Description\n").append(this.events.stream().map(KeyValueEntry::toString).collect(Collectors.joining("\n")))
-                    .append("\n|===");
-        }
-        return text.toString();
-    }
-
     private String spanName() {
         String name = Arrays.stream(enumName.replace("_", " ").split(" ")).map(s -> StringUtils.capitalize(s.toLowerCase(Locale.ROOT))).collect(Collectors.joining(" "));
         if (!name.toLowerCase(Locale.ROOT).endsWith("span")) {
@@ -160,5 +129,41 @@ class SpanEntry implements Comparable<SpanEntry> {
             return "`" + this.nameFromConventionClass + "` (defined by convention class `" + this.conventionClass + "`)";
         }
         return "Unable to resolve the name - please check the convention class `" + this.conventionClass + "` for more details";
+    }
+
+    public String getSpanTitle() {
+        // TODO: convert to handlebar helper
+        return spanName();
+    }
+    public String getDisplayName() {
+        return name();
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getEnumName() {
+        return this.enumName;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public String getEnclosingClass() {
+        return this.enclosingClass;
+    }
+
+    public String getPrefix() {
+        return this.prefix;
+    }
+
+    public Collection<KeyValueEntry> getTagKeys() {
+        return this.tagKeys;
+    }
+
+    public Collection<KeyValueEntry> getEvents() {
+        return this.events;
     }
 }

--- a/micrometer-docs-generator-spans/src/main/resources/templates/spans.adoc.hbs
+++ b/micrometer-docs-generator-spans/src/main/resources/templates/spans.adoc.hbs
@@ -1,0 +1,48 @@
+{{!
+    This is a handlebars template file for metrics documentation.
+~}}
+[[observability-spans]]
+=== Observability - Spans
+
+Below you can find a list of all spans declared by this project.
+
+{{#each entries~}}
+
+[[observability-spans-{{slugify (lower (replace enumName "_" " "))}}]]
+==== {{capitalize (lower (replace spanTitle "_" " "))}}
+
+> {{{description}}}
+
+**Span name** {{{displayName}}}{{#if (isDynamic name)}} - since it contains `%s`, the name is dynamic and will be resolved at runtime{{/if}}.
+
+Fully qualified name of the enclosing class `{{enclosingClass}}`.
+
+{{#if prefix~}}
+IMPORTANT: All tags must be prefixed with `{{prefix}}` prefix!
+{{~/if}}
+
+{{#each tagKeys~}}
+{{~#if @first~}}
+.Tag Keys
+|===
+|Name | Description
+{{~/if}}
+|`{{this.name}}`|{{{this.displayDescription}}}
+{{~#if @last}}
+|===
+{{~/if}}
+{{~/each}}
+
+{{#each events~}}
+{{~#if @first~}}
+.Event Values
+|===
+|Name | Description
+{{~/if}}
+|`{{this.name}}`|{{{this.displayDescription}}}
+{{~#if @last}}
+|===
+{{~/if}}
+{{~/each}}
+
+{{/each}}


### PR DESCRIPTION
Instead of using `toString()`, templatize the adoc generation using Handlebars.