### PR TITLE
Upgrade dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,19 @@ updates:
     target-branch: "1.0.x" # oldest OSS supported branch
     schedule:
       interval: "weekly"
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: daily
+    target-branch: 1.0.x
+    ignore:
+      # only upgrade patch versions for maintenance branch
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: daily
+    target-branch: main


### PR DESCRIPTION
Configures dependabot to upgrade patch versions in maintenance branches and any version in `main`. We may want to fine tune this more, but this should be a start.

Whenever a new maintenance branch is created, it should be added to this config file. Likewise, whenever a branch is no longer maintained, it should be removed from this file so we no longer receive pull requests to it automatically.