### PR TITLE
fix: github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,9 @@
 ---
-name: Bug report about: Report a bug in Micrometer Docs Generator title: ''
-labels: bug assignees: ''
-
+name: Bug report
+about: Report a bug in Micrometer Docs Generator
+title: ''
+labels: bug
+assignees: ''
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -1,7 +1,9 @@
 ---
-name: Enhancement request about: Request an enhancement for Micrometer title: ''
-labels: enhancement assignees: ''
-
+name: Enhancement request
+about: Request an enhancement for Micrometer
+title: ''
+labels: enhancement
+assignees: ''
 ---
 
 **Please describe the feature request.**


### PR DESCRIPTION
This PR fixes the issue templates, which were wrong formatted and couldn't be picked when creating a new issue.