### PR TITLE
Add sub classing interfaces

### DIFF
--- a/micrometer-docs-generator/src/main/java/io/micrometer/docs/commons/AbstractSearchingFileVisitor.java
+++ b/micrometer-docs-generator/src/main/java/io/micrometer/docs/commons/AbstractSearchingFileVisitor.java
@@ -34,6 +34,7 @@ import io.micrometer.docs.commons.utils.StringUtils;
 import org.jboss.forge.roaster.Roaster;
 import org.jboss.forge.roaster.model.source.EnumConstantSource;
 import org.jboss.forge.roaster.model.source.JavaEnumSource;
+import org.jboss.forge.roaster.model.source.JavaInterfaceSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 
@@ -70,6 +71,20 @@ public abstract class AbstractSearchingFileVisitor extends SimpleFileVisitor<Pat
             return FileVisitResult.CONTINUE;
         }
         JavaEnumSource enumSource = (JavaEnumSource) javaSource;
+
+        enumSource.getInterfaces().forEach(interfaceName -> {
+            // Find any interfaces that match our supported interfaces
+            JavaInterfaceSource foundInterface = searchHelper.searchExtendingDocumentationInterfaceName(interfaceName,
+                    this);
+            if (foundInterface != null) {
+                try {
+                    supportedInterfaces().add(Class.forName(interfaceName));
+                }
+                catch (ClassNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
 
         if (supportedInterfaces().stream().noneMatch(enumSource::hasInterface)) {
             return FileVisitResult.CONTINUE;

--- a/micrometer-docs-generator/src/main/java/io/micrometer/docs/metrics/MetricSearchingFileVisitor.java
+++ b/micrometer-docs-generator/src/main/java/io/micrometer/docs/metrics/MetricSearchingFileVisitor.java
@@ -56,6 +56,9 @@ class MetricSearchingFileVisitor extends AbstractSearchingFileVisitor {
 
     private final Collection<MetricEntry> entries;
 
+    private final Collection<Class<?>> supportedInterfaces = new ArrayList<>(
+            Arrays.asList(MeterDocumentation.class, ObservationDocumentation.class));
+
     MetricSearchingFileVisitor(Pattern pattern, Collection<MetricEntry> entries, JavaSourceSearchHelper searchHelper) {
         super(pattern, searchHelper);
         this.entries = entries;
@@ -63,7 +66,7 @@ class MetricSearchingFileVisitor extends AbstractSearchingFileVisitor {
 
     @Override
     public Collection<Class<?>> supportedInterfaces() {
-        return Arrays.asList(MeterDocumentation.class, ObservationDocumentation.class);
+        return supportedInterfaces;
     }
 
     @Override

--- a/micrometer-docs-generator/src/main/java/io/micrometer/docs/spans/SpanSearchingFileVisitor.java
+++ b/micrometer-docs-generator/src/main/java/io/micrometer/docs/spans/SpanSearchingFileVisitor.java
@@ -56,6 +56,9 @@ class SpanSearchingFileVisitor extends AbstractSearchingFileVisitor {
 
     private final Collection<SpanEntry> spanEntries;
 
+    private final Collection<Class<?>> supportedInterfaces = new ArrayList<>(
+            Arrays.asList(SpanDocumentation.class, ObservationDocumentation.class));
+
     /**
      * The enclosing enum classes for overriding will be excluded from documentation
      */
@@ -68,7 +71,7 @@ class SpanSearchingFileVisitor extends AbstractSearchingFileVisitor {
 
     @Override
     public Collection<Class<?>> supportedInterfaces() {
-        return Arrays.asList(SpanDocumentation.class, ObservationDocumentation.class);
+        return supportedInterfaces;
     }
 
     @Override

--- a/micrometer-docs-generator/src/test/java/io/micrometer/docs/metrics/test2/ExtendExtendedMeterDoc.java
+++ b/micrometer-docs-generator/src/test/java/io/micrometer/docs/metrics/test2/ExtendExtendedMeterDoc.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.docs.metrics.test2;
+
+import java.io.Serializable;
+
+// Added any interface (Serializable) to test if the parser really goes through all extending interfaces
+public interface ExtendExtendedMeterDoc extends Serializable, ExtendMeterDocumentation {
+
+    String secondDescription();
+
+}

--- a/micrometer-docs-generator/src/test/java/io/micrometer/docs/metrics/test2/ExtendExtendedMyMetrics.java
+++ b/micrometer-docs-generator/src/test/java/io/micrometer/docs/metrics/test2/ExtendExtendedMyMetrics.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.docs.metrics.test2;
+
+import io.micrometer.core.instrument.Meter;
+
+public enum ExtendExtendedMyMetrics implements ExtendExtendedMeterDoc {
+
+    /**
+     * Test metric which extends the extended MeterDocumentation interface.
+     */
+    EXTEND_EXTENDED_FOO {
+        @Override
+        public String secondDescription() {
+            return "This comes from ExtendedExtendMeterDoc interface";
+        }
+
+        @Override
+        public String getDescription() {
+            return "This comes from ExtendMeterDocumentation interface";
+        }
+
+        @Override
+        public String getName() {
+            return "extend.extended.foo";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.COUNTER;
+        }
+    }
+
+}

--- a/micrometer-docs-generator/src/test/java/io/micrometer/docs/metrics/test2/ExtendMeterDocumentation.java
+++ b/micrometer-docs-generator/src/test/java/io/micrometer/docs/metrics/test2/ExtendMeterDocumentation.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.docs.metrics.test2;
+
+import io.micrometer.core.instrument.docs.MeterDocumentation;
+
+public interface ExtendMeterDocumentation extends MeterDocumentation {
+
+    /**
+     * Returns the description (also known as {@code help} in some systems) for the given
+     * meter.
+     */
+    String getDescription();
+
+}

--- a/micrometer-docs-generator/src/test/java/io/micrometer/docs/metrics/test2/ExtendedMyMetrics.java
+++ b/micrometer-docs-generator/src/test/java/io/micrometer/docs/metrics/test2/ExtendedMyMetrics.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.docs.metrics.test2;
+
+import io.micrometer.core.instrument.Meter;
+
+public enum ExtendedMyMetrics implements ExtendMeterDocumentation {
+
+    /**
+     * Test metric which extends the MeterDocumentation interface
+     */
+    FOO {
+        @Override
+        public String getDescription() {
+            return "foo metric";
+        }
+
+        @Override
+        public String getName() {
+            return "extended.foo";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.COUNTER;
+        }
+    };
+
+}

--- a/micrometer-docs-generator/src/test/java/io/micrometer/docs/metrics/test2/MetricSearchingFileVisitorTest.java
+++ b/micrometer-docs-generator/src/test/java/io/micrometer/docs/metrics/test2/MetricSearchingFileVisitorTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.docs.metrics.test2;
+
+import io.micrometer.docs.metrics.MetricsDocGenerator;
+import org.assertj.core.api.BDDAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+class MetricSearchingFileVisitorTest {
+
+    @Test
+    void should_render_metrics_from_sub_class_interfaces() throws IOException {
+        Path output = Paths.get(".", "build", "_metrics.adoc");
+
+        File sourceRoot = new File(".", "src/test");
+        new MetricsDocGenerator(sourceRoot, Pattern.compile(".*/docs/metrics/test2/[a-zA-Z]+\\.java"),
+                "templates/metrics.adoc.hbs", output)
+            .generate();
+
+        BDDAssertions.then(new String(Files.readAllBytes(output)))
+            .contains("**Metric name** `extended.foo`. **Type** `counter`")
+            .contains("**Metric name** `extend.extended.foo`. **Type** `counter`");
+    }
+
+}

--- a/micrometer-docs-generator/src/test/java/io/micrometer/docs/spans/test7/ExtendExtendedMySpan.java
+++ b/micrometer-docs-generator/src/test/java/io/micrometer/docs/spans/test7/ExtendExtendedMySpan.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.docs.spans.test7;
+
+public enum ExtendExtendedMySpan implements ExtendExtendedSpanDocumentation {
+
+    /**
+     * Test span for sub-classing documentation interfaces
+     */
+    EXTEND_EXTENDED_FOO {
+        @Override
+        public String secondDescription() {
+            return "This comes from ExtendExtendedSpanDocumentation";
+        }
+
+        @Override
+        public String getDescription() {
+            return "This comes from ExtendSpanDocumentation";
+        }
+
+        @Override
+        public String getName() {
+            return "extend extended foo";
+        }
+    }
+
+}

--- a/micrometer-docs-generator/src/test/java/io/micrometer/docs/spans/test7/ExtendExtendedSpanDocumentation.java
+++ b/micrometer-docs-generator/src/test/java/io/micrometer/docs/spans/test7/ExtendExtendedSpanDocumentation.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.docs.spans.test7;
+
+public interface ExtendExtendedSpanDocumentation extends ExtendSpanDocumentation {
+
+    String secondDescription();
+
+}

--- a/micrometer-docs-generator/src/test/java/io/micrometer/docs/spans/test7/ExtendSpanDocumentation.java
+++ b/micrometer-docs-generator/src/test/java/io/micrometer/docs/spans/test7/ExtendSpanDocumentation.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.docs.spans.test7;
+
+import io.micrometer.tracing.docs.SpanDocumentation;
+
+public interface ExtendSpanDocumentation extends SpanDocumentation {
+
+    String getDescription();
+
+}

--- a/micrometer-docs-generator/src/test/java/io/micrometer/docs/spans/test7/ExtendedMySpan.java
+++ b/micrometer-docs-generator/src/test/java/io/micrometer/docs/spans/test7/ExtendedMySpan.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.docs.spans.test7;
+
+public enum ExtendedMySpan implements ExtendSpanDocumentation {
+
+    /**
+     * Test span for sub-classing documentation interfaces
+     */
+    FOO {
+        @Override
+        public String getDescription() {
+            return "Description method from ExtendSpanDocumentation";
+        }
+
+        @Override
+        public String getName() {
+            return "extended foo";
+        }
+    }
+
+}

--- a/micrometer-docs-generator/src/test/java/io/micrometer/docs/spans/test7/SpanSearchingFileVisitorTest.java
+++ b/micrometer-docs-generator/src/test/java/io/micrometer/docs/spans/test7/SpanSearchingFileVisitorTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.docs.spans.test7;
+
+import io.micrometer.docs.spans.SpansDocGenerator;
+import org.assertj.core.api.BDDAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
+class SpanSearchingFileVisitorTest {
+
+    @Test
+    void should_render_spans_from_sub_class_interfaces() throws IOException {
+        File root = new File("./src/test/java/io/micrometer/docs/spans/test7");
+        Path output = Paths.get(".", "build/test7", "_spans.adoc");
+        Files.createDirectories(output.getParent());
+
+        new SpansDocGenerator(root, Pattern.compile(".*"), "templates/spans.adoc.hbs", output).generate();
+
+        BDDAssertions.then(new String(Files.readAllBytes(output)))
+            .contains("**Span name** `extended foo`.")
+            .contains("**Span name** `extend extended foo`.");
+    }
+
+}


### PR DESCRIPTION
This implementation enables sub-classing of the documentation interfaces, in order to get them recognized by the plugin as described in #338.
I've added some tests to ensure behaves as expected, let me know if I should add some more cases.

This closes [gh-338](https://github.com/micrometer-metrics/micrometer-docs-generator/issues/338)